### PR TITLE
Modified Regex pattern to accept commands besides full executable path.

### DIFF
--- a/Warden.Tests/W32LauncherTests.cs
+++ b/Warden.Tests/W32LauncherTests.cs
@@ -1,0 +1,48 @@
+﻿using Warden.Core;
+using Xunit;
+
+namespace Warden.Tests
+{
+   public class W32LauncherTests
+   {
+      public W32LauncherTests()
+      {
+         WardenManager.Initialize(new WardenOptions());
+      }
+
+      [Fact]
+      public async void Given_EnvironmentPathIsSet_When_CommandIsTypedInsteadOfPath_LauncherShouldStart()
+      {
+         const string command = "cmd";
+         WardenProcess testProcess = null;
+         try
+         {
+            testProcess = await WardenProcess.Start(command, string.Empty);
+
+         }
+         catch
+         {
+         }
+
+         Assert.NotNull(testProcess);
+      }
+
+      [Fact]
+      public async void Given_EnvironmentPathIsNotSet_When_CommandIsTypedInsteadOfPath_LauncherShouldThrowException()
+      {
+         const string command = "incorrectCommand";
+
+         WardenProcess testProcess = null;
+         try
+         {
+            testProcess = await WardenProcess.Start(command, string.Empty);
+
+         }
+         catch
+         {
+         }
+
+         Assert.Null(testProcess);
+      }
+   }
+}

--- a/Warden.Tests/Warden.Tests.csproj
+++ b/Warden.Tests/Warden.Tests.csproj
@@ -59,6 +59,7 @@
   <ItemGroup>
     <Compile Include="TestWardenOnTestProcess.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="W32LauncherTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Warden/Core/Launchers/Win32Launcher.cs
+++ b/Warden/Core/Launchers/Win32Launcher.cs
@@ -13,7 +13,7 @@ namespace Warden.Core.Launchers
 {
     internal class Win32Launcher : ILauncher
     {
-        internal static Regex ProgramPath = new Regex(@"([A-Z]:\\[^/:\*\?<>\|]+\.((exe)))|(\\{2}[^/:\*\?<>\|]+\.((exe)))", RegexOptions.IgnoreCase);
+        internal static Regex ProgramPath = new Regex(@"^.([A-Z]:\\[^/:\*\?<>\|]+\.((exe)))|^.(\\{2}[^/:\*\?<>\|]+\.((exe)))|^.([A-Z0-9]*)", RegexOptions.IgnoreCase);
 
         internal static Regex Arguments =
             new Regex(


### PR DESCRIPTION
Although it's the default behavior, the regex pattern added with commit https://github.com/RainwayApp/warden/commit/4948bd6a31df4ad6c528426302b9ee4e20e9ddce  does not accept commands from environment paths, as I have mentioned on issue https://github.com/RainwayApp/warden/issues/6 . So I changed the pattern to accept commands like cmd. Tests are working but they are not ideal solutions, just workarounds. It needs some refactoring yet still capable of esting the condition.